### PR TITLE
add option to run local operators

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -9,6 +9,20 @@ source lib/common.sh
 eval "$(go env)"
 export GOPATH
 
+# Environment variables
+# M3PATH : Path to clone the metal3 dev env repo
+# BMOPATH : Path to clone the baremetal operator repo
+# CAPBMPATH: Path to clone the CAPI operator repo
+#
+# BMOREPO : Baremetal operator repository URL
+# BMOBRANCH : Baremetal operator repository branch to checkout
+# CAPBMREPO : CAPI operator repository URL
+# CAPBMBRANCH : CAPI repository branch to checkout
+# FORCE_REPO_UPDATE : discard existing directories
+#
+# BMO_RUN_LOCAL : run the baremetal operator locally (not in Kubernetes cluster)
+# CAPBM_RUN_LOCAL : run the CAPI operator locally
+
 M3PATH="${GOPATH}/src/github.com/metal3-io"
 BMOPATH="${M3PATH}/baremetal-operator"
 CAPBMPATH="${M3PATH}/cluster-api-provider-baremetal"

--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -7,6 +7,7 @@ source lib/logging.sh
 source lib/common.sh
 
 eval "$(go env)"
+export GOPATH
 
 M3PATH="${GOPATH}/src/github.com/metal3-io"
 BMOPATH="${M3PATH}/baremetal-operator"
@@ -17,6 +18,9 @@ BMOBRANCH="${BMOBRANCH:-master}"
 CAPBMREPO="${CAPBMREPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 CAPBMBRANCH="${CAPBMBRANCH:-master}"
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
+
+BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
+CAPBM_RUN_LOCAL="${CAPBM_RUN_LOCAL:-false}"
 
 function clone_repos() {
     mkdir -p "${M3PATH}"
@@ -63,7 +67,15 @@ function launch_minikube() {
 
 function launch_baremetal_operator() {
     pushd "${BMOPATH}"
-    make deploy
+    if [ "${BMO_RUN_LOCAL}" = true ]; then
+      touch bmo.out.log
+      touch bmo.err.log
+      make deploy
+      kubectl scale deployment metal3-baremetal-operator -n metal3 --replicas=0
+      nohup make run >> bmo.out.log 2>>bmo.err.log &
+    else
+      make deploy
+    fi
     popd
 }
 
@@ -89,7 +101,15 @@ function apply_bm_hosts() {
 #
 function launch_cluster_api() {
     pushd "${CAPBMPATH}"
-    make deploy
+    if [ "${CAPBM_RUN_LOCAL}" = true ]; then
+      touch capbm.out.log
+      touch capbm.err.log
+      make deploy
+      kubectl scale statefulset cluster-api-provider-baremetal-controller-manager -n metal3 --replicas=0
+      nohup make run >> capbm.out.log 2>> capbm.err.log &
+    else
+      make deploy
+    fi
     popd
 }
 

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -105,9 +105,12 @@ check_k8s_entity() {
     FAILS="$(process_status $? "${1} ${name} created")"
 
     # Check the replicas
-    FAILS="$(equals "$(echo "${ENTITY}" | jq -r '.status.readyReplicas')" \
-      "$(echo "${ENTITY}" | jq -r '.status.replicas')" \
-      "${name} ${1} replicas correct")"
+    if [[ "${BMO_RUN_LOCAL}" != true ]] && [[ "${CAPBM_RUN_LOCAL}" != true ]]
+    then
+      FAILS="$(equals "$(echo "${ENTITY}" | jq -r '.status.readyReplicas')" \
+        "$(echo "${ENTITY}" | jq -r '.status.replicas')" \
+        "${name} ${1} replicas correct")"
+    fi
   done
   echo "" >&3
   echo "${FAILS}"
@@ -122,9 +125,12 @@ check_k8s_rs() {
     FAILS="$(differs "${ENTITY}" "null" "Replica set ${name} created")"
 
     # Check the replicas
-    FAILS="$(equals "$(echo "${ENTITY}" | jq -r '.status.readyReplicas')" \
-      "$(echo "${ENTITY}" | jq -r '.status.replicas')" \
-      "${name} replicas correct")"
+    if [[ "${BMO_RUN_LOCAL}" != true ]] && [[ "${CAPBM_RUN_LOCAL}" != true ]]
+    then
+      FAILS="$(equals "$(echo "${ENTITY}" | jq -r '.status.readyReplicas')" \
+        "$(echo "${ENTITY}" | jq -r '.status.replicas')" \
+        "${name} replicas correct")"
+    fi
   done
   echo "" >&3
   echo "${FAILS}"
@@ -143,6 +149,9 @@ EXPTD_DEPLOYMENTS="metal3-baremetal-operator"
 BRIDGES="provisioning baremetal"
 
 FAILS=0
+BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
+CAPBM_RUN_LOCAL="${CAPBM_RUN_LOCAL:-false}"
+
 
 # Verify networking
 for bridge in ${BRIDGES}; do

--- a/04_verify.sh
+++ b/04_verify.sh
@@ -194,6 +194,14 @@ FAILS=$(check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}")
 # Verify the Operators, Replica sets
 FAILS=$(check_k8s_rs "${EXPTD_DEPLOYMENTS}")
 
+if [[ "${BMO_RUN_LOCAL}" == true ]]; then
+  pgrep "operator-sdk" > /dev/null 2> /dev/null
+  FAILS=$(process_status $? "Baremetal operator locally running")
+fi
+if [[ "${CAPBM_RUN_LOCAL}" == true ]]; then
+  pgrep -f "go run ./cmd/manager/main.go" > /dev/null 2> /dev/null
+  FAILS=$(process_status $? "CAPI operator locally running")
+fi
 
 #Verify Ironic containers are running
 for name in ironic ironic-inspector dnsmasq httpd mariadb; do

--- a/config_example.sh
+++ b/config_example.sh
@@ -46,3 +46,13 @@
 # Force deletion of the BMO and CAPBM repositories before cloning them again
 #
 #export FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
+
+#
+# Run a local baremetal operator instead of deploying in Kubernetes
+#
+#export BMO_RUN_LOCAL=true
+
+#
+# Run a local CAPI operator instead of deploying in Kubernetes
+#
+#export CAPBM_RUN_LOCAL=true

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -19,6 +19,19 @@ if [[ "${CONTAINER_RUNTIME}" == "podman" ]]; then
   fi
 fi
 
+# Kill the locally running operators
+if [ "${BMO_RUN_LOCAL}" = true ]; then
+  kill "$(pgrep "operator-sdk")" 2> /dev/null || true
+fi
+if [ "${CAPBM_RUN_LOCAL}" = true ]; then
+  CAPBM_PARENT_PID="$(pgrep -f "go run ./cmd/manager/main.go")"
+  if [[ "${CAPBM_PARENT_PID}" != "" ]]; then
+    CAPBM_GO_PID="$(pgrep -P "${CAPBM_PARENT_PID}" )"
+    kill "${CAPBM_GO_PID}"  2> /dev/null || true
+  fi
+fi
+
+
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "working_dir=$WORKING_DIR" \
     -e "num_masters=$NUM_MASTERS" \


### PR DESCRIPTION
Instead of using 'make deploy' for Baremetal Operator and CAPI
provider baremetal, add an option to use 'make run' and log the
output.