### PR TITLE
Add retries in verification script and provisioning tests

### DIFF
--- a/04_verify.sh
+++ b/04_verify.sh
@@ -12,96 +12,85 @@ source lib/logging.sh
 source lib/common.sh
 
 
-# Check the return code and log
-process_status(){
-  if [[ "${1}" == 0 ]]; then
-    echo "OK - ${2}" >&3
-    echo "${FAILS}"
-  else
-    echo "FAIL - ${2}" >&3
-    echo "$((FAILS+1))"
-  fi
-}
-
-
-# Compare the two inputs and log
-equals(){
-  if [[ "${1}" == "${2}" ]]; then
-    echo "OK - ${3}" >&3
-    echo "${FAILS}"
-  else
-    echo "FAIL - ${3}" >&3
-    echo "$((FAILS+1))"
-  fi
-}
-
-
-# Compare the two inputs and log
-differs(){
-  if [[ "${1}" != "${2}" ]]; then
-    echo "OK - ${3}" >&3
-    echo "${FAILS}"
-  else
-    echo "FAIL - ${3}" >&3
-    echo "$((FAILS+1))"
-  fi
-}
-
-
 check_bm_hosts() {
-    while read -r name address user password mac; do
-      BM_VMNAME="${name//-/_}"
-      # Verify BM host exists
-      echo "$BM_HOSTS" | grep -w "${name}"  > /dev/null
-      FAILS="$(process_status $? "${name} Baremetalhost exist")"
+    local FAILS_CHECK="${FAILS}"
+    local NAME ADDRESS USER PASSWORD MAC CRED_NAME CRED_SECRET\
+      BM_HOSTS BM_HOST BM_VMS BM_VMNAME BM_VM_IFACES
+    NAME="${1}"
+    ADDRESS="${2}"
+    USER="${3}"
+    PASSWORD="${4}"
+    MAC="${5}"
+    BM_HOSTS="$(kubectl --kubeconfig "${KUBECONFIG}" get baremetalhosts\
+      -n metal3 -o json)"
+    BM_VMS="$(virsh list --all)"
+    BM_VMNAME="${NAME//-/_}"
+    # Verify BM host exists
+    echo "$BM_HOSTS" | grep -w "${NAME}"  > /dev/null
+    FAILS="$(process_status $? "${NAME} Baremetalhost exist")"
 
-      BM_HOST="$(echo "${BM_HOSTS}" | jq ' .items[] | select(.metadata.name=="'"${name}"'" )')"
+    BM_HOST="$(echo "${BM_HOSTS}" | \
+      jq ' .items[] | select(.metadata.name=="'"${NAME}"'" )')"
 
-      # Verify addresses of the host
-      FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.spec.bmc.address')" \
-        "${address}" "${name} Baremetalhost address correct")"
+    # Verify addresses of the host
+    FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.spec.bmc.address')" \
+      "${ADDRESS}" "${NAME} Baremetalhost address correct")"
 
-      FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.spec.bootMACAddress')" \
-        "${mac}" "${name} Baremetalhost mac address correct")"
+    FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.spec.bootMACAddress')" \
+      "${MAC}" "${NAME} Baremetalhost mac address correct")"
 
-      # Verify BM host status
-      FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.status.operationalStatus')" \
-        "OK" "${name} Baremetalhost status OK")"
+    # Verify BM host status
+    FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.status.operationalStatus')" \
+      "OK" "${NAME} Baremetalhost status OK")"
 
-      # Verify credentials exist
-      CRED_NAME="$(echo "${BM_HOST}" | jq -r '.spec.bmc.credentialsName')"
-      CRED_SECRET="$(kubectl get secret "${CRED_NAME}" -n metal3 -o json | jq '.data')"
+    # Verify credentials exist
+    CRED_NAME="$(echo "${BM_HOST}" | jq -r '.spec.bmc.credentialsName')"
+    CRED_SECRET="$(kubectl get secret "${CRED_NAME}" -n metal3 -o json | \
+      jq '.data')"
+    FAILS="$(process_status $? \
+      "${NAME} Baremetalhost credentials secret exist")"
+
+    # Verify credentials correct
+    FAILS="$(equals "$(echo "${CRED_SECRET}" | jq -r '.password' | \
+      base64 --decode)" \
+      "${PASSWORD}" "${NAME} Baremetalhost password correct")"
+
+    FAILS="$(equals "$(echo "${CRED_SECRET}" | jq -r '.username' | \
+      base64 --decode)" \
+      "${USER}" "${NAME} Baremetalhost user correct")"
+
+    # Verify the VM was created
+    echo "$BM_VMS "| grep -w "${BM_VMNAME}"  > /dev/null
+    FAILS="$(process_status $? "${NAME} Baremetalhost VM exist")"
+
+    #Verify the VMs interfaces
+    BM_VM_IFACES="$(virsh domiflist "${BM_VMNAME}")"
+    for bridge in ${BRIDGES}; do
+      echo "$BM_VM_IFACES" | grep -w "${bridge}"  > /dev/null
       FAILS="$(process_status $? \
-        "${name} Baremetalhost credentials secret exist")"
-
-      # Verify credentials correct
-      FAILS="$(equals "$(echo "${CRED_SECRET}" | jq -r '.password' | base64 --decode)" \
-        "${password}" "${name} Baremetalhost password correct")"
-
-      FAILS="$(equals "$(echo "${CRED_SECRET}" | jq -r '.username' | base64 --decode)" \
-        "${user}" "${name} Baremetalhost user correct")"
-
-      # Verify the VM was created
-      echo "$BM_VMS "| grep -w "${BM_VMNAME}"  > /dev/null
-      FAILS="$(process_status $? "${name} Baremetalhost VM exist")"
-
-      BM_VM_IFACES="$(virsh domiflist "${BM_VMNAME}")"
-      for bridge in ${BRIDGES}; do
-        echo "$BM_VM_IFACES" | grep -w "${bridge}"  > /dev/null
-        FAILS="$(process_status $? \
-          "${name} Baremetalhost VM interface ${bridge} exist")"
-      done
-      echo "" >&3
+        "${NAME} Baremetalhost VM interface ${bridge} exist")"
     done
+
+    #Verify the instrospection completed successfully
+    FAILS="$(equals "$(echo "${BM_HOST}" | jq -r '.status.provisioning.state')" \
+      "ready" "${NAME} Baremetalhost introspecting completed")"
+    echo "" >&3
     echo "${FAILS}"
+    if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+      return 1
+    fi
+    return 0
 }
 
 
 #Verify that a resource exists in a type
 check_k8s_entity() {
+  local FAILS_CHECK="${FAILS}"
+  local ENTITY
   for name in ${2}; do
     # Check entity exists
-    ENTITY="$(kubectl --kubeconfig "${KUBECONFIG}" get "${1}" "${name}" -n metal3 -o json)"
+    ENTITY="$(kubectl --kubeconfig "${KUBECONFIG}" get "${1}" "${name}" \
+      -n metal3 -o json)"
     FAILS="$(process_status $? "${1} ${name} created")"
 
     # Check the replicas
@@ -114,14 +103,21 @@ check_k8s_entity() {
   done
   echo "" >&3
   echo "${FAILS}"
+  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+    return 1
+  fi
+  return 0
 }
 
 
 #Verify that a resource exists in a type
 check_k8s_rs() {
+  local FAILS_CHECK="${FAILS}"
+  local ENTITY
   for name in ${1}; do
     # Check entity exists
-    ENTITY="$(kubectl --kubeconfig "${KUBECONFIG}" get replicasets -l name="${name}" -n metal3 -o json | jq '.items[0]')"
+    ENTITY="$(kubectl --kubeconfig "${KUBECONFIG}" get replicasets \
+      -l name="${name}" -n metal3 -o json | jq '.items[0]')"
     FAILS="$(differs "${ENTITY}" "null" "Replica set ${name} created")"
 
     # Check the replicas
@@ -134,6 +130,18 @@ check_k8s_rs() {
   done
   echo "" >&3
   echo "${FAILS}"
+  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#Verify a container is running
+check_container(){
+  local NAME="$1"
+  sudo "${CONTAINER_RUNTIME}" ps | grep -w "$NAME$" > /dev/null
+  process_status $? "Container ${NAME} running"
+  return $?
 }
 
 KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
@@ -175,24 +183,29 @@ for name in ${EXPTD_CRDS}; do
 done
 echo "" >&3
 
-# Verify the baremetal hosts
-## Fetch the BM CRs
-BM_HOSTS="$(kubectl --kubeconfig "${KUBECONFIG}" get baremetalhosts -n metal3 -o json)"
-FAILS=$(process_status $? "Fetch Baremetalhosts")
-## Fetch the VMs
-BM_VMS="$(virsh list --all)"
-FAILS=$(process_status $? "Fetch Baremetalhosts VMs")
-## Verify
-FAILS="$(list_nodes | check_bm_hosts)"
 
 # Verify the Operators, stateful sets
-FAILS=$(check_k8s_entity statefulsets "${EXPTD_STATEFULSETS}")
+FAILS=$(iterate check_k8s_entity statefulsets "${EXPTD_STATEFULSETS}")
 
 # Verify the Operators, Deployments
-FAILS=$(check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}")
+FAILS=$(iterate check_k8s_entity deployments "${EXPTD_DEPLOYMENTS}")
 
 # Verify the Operators, Replica sets
-FAILS=$(check_k8s_rs "${EXPTD_DEPLOYMENTS}")
+FAILS=$(iterate check_k8s_rs "${EXPTD_DEPLOYMENTS}")
+
+# Verify the baremetal hosts
+## Fetch the BM CRs
+kubectl --kubeconfig "${KUBECONFIG}" get baremetalhosts -n metal3 -o json \
+  > /dev/null
+FAILS=$(process_status $? "Fetch Baremetalhosts")
+## Fetch the VMs
+virsh list --all > /dev/null
+FAILS=$(process_status $? "Fetch Baremetalhosts VMs")
+## Verify
+while read -r name address user password mac; do
+  FAILS="$(iterate check_bm_hosts "${name}" "${address}" "${user}" \
+    "${password}" "${mac}")"
+done <<< "$(list_nodes)"
 
 if [[ "${BMO_RUN_LOCAL}" == true ]]; then
   pgrep "operator-sdk" > /dev/null 2> /dev/null
@@ -205,8 +218,7 @@ fi
 
 #Verify Ironic containers are running
 for name in ironic ironic-inspector dnsmasq httpd mariadb; do
-  sudo "${CONTAINER_RUNTIME}" ps | grep -w "$name$" > /dev/null
-  FAILS=$(process_status $? "Container ${name} running")
+  FAILS="$(iterate check_container "${name}")"
 done
 echo "" >&3
 

--- a/05_test.sh
+++ b/05_test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+
+set -u
+
+# Redirect to stdout for logging
+# Workaround to avoid returning logs in functions
+exec 3>&1
+
+# shellcheck disable=SC1091
+source lib/logging.sh
+# shellcheck disable=SC1091
+source lib/common.sh
+
+FAILS=0
+SKIP_RETRIES_USER="${SKIP_RETRIES:-false}"
+MACHINES_LIST="centos-0 centos-1"
+
+#
+# Tries to run a command over ssh in the machine
+#
+# Inputs:
+# - the ssh user
+# - the server ip or domain
+# - The baremetal host name
+#
+ssh_to_machine() {
+  local USER SERVER MACHINE_NAME
+
+  USER="${1:?}"
+  SERVER="${2:?}"
+  MACHINE_NAME="${3:?}"
+
+  ssh -o ConnectTimeout=2 \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    "${USER}"@"${SERVER}" echo "SSH to host is up" > /dev/null 2>&1
+  RET_CODE="$?"
+  process_status "${RET_CODE}" "${MACHINE_NAME} baremetal host reachable by ssh"
+  return "${RET_CODE}"
+}
+
+#
+# Checks the provisioning status of the baremetal host
+#
+# Inputs:
+# - machine name
+# - Baremetal host name
+# - Expected state
+#
+check_provisioning_status(){
+  local MACHINE_NAME="${1}"
+  local BMH_NAME="${2}"
+  local FAILS_CHECK
+  local EXPECTED_STATE="${3}"
+  FAILS_CHECK="${FAILS}"
+  BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
+
+  FAILS="$(equals "$(echo "${BMH}" | jq -r '.status.provisioning.state')" \
+    "${EXPECTED_STATE}" \
+    "${MACHINE_NAME} baremetal host in correct state : ${EXPECTED_STATE}")"
+  echo "${FAILS}"
+  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# Check that the machine and baremetal host CRs are cross-referencing
+#
+# Inputs:
+# - Machine name
+# - Baremetal host name
+#
+check_bmh_association(){
+  local MACHINE_NAME="${1}"
+  local BMH_NAME
+  local FAILS_CHECK
+  FAILS_CHECK="${FAILS}"
+  MACHINE="$(kubectl get machine -n metal3 -o json "${MACHINE_NAME}")"
+  BMH_NAME="$(echo "${MACHINE}" | \
+    jq -r '.metadata.annotations["metal3.io/BareMetalHost"]' | \
+    tr '/' ' ' | awk '{print $2}')"
+  FAILS="$(is_in "${BMH_NAME}" \
+    "master-0 worker-0" \
+    "${MACHINE_NAME} Baremetalhost associated")"
+
+  # Fail fast if they are not associated as we cannot get the BMH name
+  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+    echo "${FAILS}"
+    return 1
+  fi
+
+  # Verify the existence of the bmh
+  BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
+  FAILS="$(process_status $? "${BMH_NAME} baremetal host CR exist")"
+
+  # Check the consumer ref
+  FAILS="$(equals "$(echo "${BMH}" | jq -r '.spec.consumerRef.name')" \
+    "${MACHINE_NAME}" \
+    "${MACHINE_NAME} Baremetal host correct consumer ref")"
+
+  echo "${FAILS}"
+  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# Checks the status fields of a baremetal host
+#
+# Inputs:
+# - machine name
+# - baremetal host name
+# - the expected content of the image field (URL)
+# - the expected content of the provisioned status
+#
+check_bmh_status(){
+  local MACHINE_NAME="${1}"
+  local BMH_NAME="${2}"
+  local IMAGE_NAME="${3}"
+  local PROVISIONED_STATUS="${4}"
+  local FAILS_CHECK
+  FAILS_CHECK="${FAILS}"
+  BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
+
+  # Verify the provisioning state of the BMH
+  FAILS="$(iterate check_provisioning_status "${MACHINE_NAME}" "${BMH_NAME}" \
+    "${PROVISIONED_STATUS}")"
+
+  #Check the image
+  FAILS="$(equals "$(echo "${BMH}" | jq -r '.spec.image.url')" \
+    "${IMAGE_NAME}" \
+    "${MACHINE_NAME} Baremetal host correct image")"
+
+  # Check the error message and operational status
+  FAILS="$(equals "$(echo "${BMH}" | jq -r '.status.errorMessage')" \
+    "" "${MACHINE_NAME} Baremetal host no error message")"
+  FAILS="$(equals "$(echo "${BMH}" | jq -r '.status.operationalStatus')" \
+    "OK" "${MACHINE_NAME} Baremetal host operational status ok")"
+
+  echo "${FAILS}"
+  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# Get the IP of a vm from the dhcp leases
+#
+# Inputs:
+# - baremetal host name
+#
+get_vm_ip(){
+  local BMH_NAME="${1}"
+  sudo virsh net-dhcp-leases baremetal | grep "${BMH_NAME}" | awk '{print $5}' \
+    | cut -d '/' -f1
+}
+
+
+# provision the machines
+for name in $MACHINES_LIST; do
+  # Create the machines
+  ./create_machine.sh "${name}" > /dev/null
+  RET_CODE="$?"
+  FAILS="$(process_status "${RET_CODE}" "${name} machine CR created")"
+  [[ "${RET_CODE}" != 0 ]] && SKIP_RETRIES=true
+done
+
+# Test provisioning
+for name in $MACHINES_LIST; do
+
+  # Verify the machine CR exists
+  kubectl get machine -n metal3 -o json "${name}" > /dev/null
+  RET_CODE="$?"
+  FAILS="$(process_status "${RET_CODE}" "${name} machine CR exist")"
+  [[ "${RET_CODE}" != 0 ]] && SKIP_RETRIES=true
+
+  #Verify that the machine has a bmh associated
+  FAILS="$(iterate check_bmh_association "${name}")"
+  # shellcheck disable=SC2181
+  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+
+  # Get the machine and BMH
+  MACHINE="$(kubectl get machine -n metal3 -o json "${name}")"
+  BMH_NAME="$(echo "${MACHINE}" | \
+    jq -r '.metadata.annotations["metal3.io/BareMetalHost"]' | \
+    tr '/' ' ' | awk '{print $2}')"
+  BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
+  # shellcheck disable=SC2181
+  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+
+  # Check the baremetal hosts status fields
+  FAILS="$(check_bmh_status "${name}" "${BMH_NAME}" "$(echo "${MACHINE}" | \
+    jq -r '.spec.providerSpec.value.image.url')" "provisioned")"
+
+  # Get the IP of the BMH
+  VM_IP="$(get_vm_ip "${BMH_NAME}")"
+  RET_CODE="$?"
+  FAILS="$(process_status "${RET_CODE}" "${name} get baremetal host IP")"
+  [[ "${RET_CODE}" != 0 ]] && SKIP_RETRIES=true
+
+  # Check ssh connection to BMH
+  FAILS="$(iterate ssh_to_machine "centos" "${VM_IP}" "${name}")"
+  # shellcheck disable=SC2181
+  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+
+  echo "" >&3
+done
+echo "" >&3
+
+SKIP_RETRIES="${SKIP_RETRIES_USER}"
+
+#Test deprovisioning
+for name in $MACHINES_LIST; do
+  # Get the machine and BMH
+  MACHINE="$(kubectl get machine -n metal3 -o json "${name}")"
+  BMH_NAME="$(echo "${MACHINE}" | \
+    jq -r '.metadata.annotations["metal3.io/BareMetalHost"]' | \
+    tr '/' ' ' | awk '{print $2}')"
+  # shellcheck disable=SC2181
+  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+
+  # Deprovision the machine
+  kubectl delete machine -n metal3 "${name}" > /dev/null
+  FAILS="$(process_status $? "${name} machine CR deleted")"
+
+  # Check the status fields of the BMH previously associated
+  FAILS="$(check_bmh_status "${name}" "${BMH_NAME}" "null" "ready")"
+  # shellcheck disable=SC2181
+  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+
+  echo "" >&3
+done
+echo "" >&3
+
+
+
+echo -e "\nNumber of failures : $FAILS" >&3
+exit "${FAILS}"

--- a/05_test.sh
+++ b/05_test.sh
@@ -2,10 +2,6 @@
 
 set -u
 
-# Redirect to stdout for logging
-# Workaround to avoid returning logs in functions
-exec 3>&1
-
 # shellcheck disable=SC1091
 source lib/logging.sh
 # shellcheck disable=SC1091
@@ -30,13 +26,13 @@ ssh_to_machine() {
   SERVER="${2:?}"
   MACHINE_NAME="${3:?}"
 
+  RESULT_STR="${MACHINE_NAME} baremetal host reachable by ssh"
   ssh -o ConnectTimeout=2 \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
     "${USER}"@"${SERVER}" echo "SSH to host is up" > /dev/null 2>&1
-  RET_CODE="$?"
-  process_status "${RET_CODE}" "${MACHINE_NAME} baremetal host reachable by ssh"
-  return "${RET_CODE}"
+  process_status "$?"
+  return "$?"
 }
 
 #
@@ -55,14 +51,10 @@ check_provisioning_status(){
   FAILS_CHECK="${FAILS}"
   BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
 
-  FAILS="$(equals "$(echo "${BMH}" | jq -r '.status.provisioning.state')" \
-    "${EXPECTED_STATE}" \
-    "${MACHINE_NAME} baremetal host in correct state : ${EXPECTED_STATE}")"
-  echo "${FAILS}"
-  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
-    return 1
-  fi
-  return 0
+  RESULT_STR="${MACHINE_NAME} baremetal host in correct state : ${EXPECTED_STATE}"
+  equals "$(echo "${BMH}" | jq -r '.status.provisioning.state')" \
+    "${EXPECTED_STATE}"
+  return "$((FAILS-FAILS_CHECK))"
 }
 
 #
@@ -81,30 +73,25 @@ check_bmh_association(){
   BMH_NAME="$(echo "${MACHINE}" | \
     jq -r '.metadata.annotations["metal3.io/BareMetalHost"]' | \
     tr '/' ' ' | awk '{print $2}')"
-  FAILS="$(is_in "${BMH_NAME}" \
-    "master-0 worker-0" \
-    "${MACHINE_NAME} Baremetalhost associated")"
+  RESULT_STR="${MACHINE_NAME} Baremetalhost associated"
+  is_in "${BMH_NAME}" "master-0 worker-0"
 
   # Fail fast if they are not associated as we cannot get the BMH name
   if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
-    echo "${FAILS}"
     return 1
   fi
 
   # Verify the existence of the bmh
+  RESULT_STR="${BMH_NAME} baremetal host CR exist"
   BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
-  FAILS="$(process_status $? "${BMH_NAME} baremetal host CR exist")"
+  process_status $?
 
   # Check the consumer ref
-  FAILS="$(equals "$(echo "${BMH}" | jq -r '.spec.consumerRef.name')" \
-    "${MACHINE_NAME}" \
-    "${MACHINE_NAME} Baremetal host correct consumer ref")"
+  RESULT_STR="${MACHINE_NAME} Baremetal host correct consumer ref"
+  equals "$(echo "${BMH}" | jq -r '.spec.consumerRef.name')" \
+    "${MACHINE_NAME}"
 
-  echo "${FAILS}"
-  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
-    return 1
-  fi
-  return 0
+  return "$((FAILS-FAILS_CHECK))"
 }
 
 #
@@ -123,28 +110,25 @@ check_bmh_status(){
   local PROVISIONED_STATUS="${4}"
   local FAILS_CHECK
   FAILS_CHECK="${FAILS}"
-  BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
 
   # Verify the provisioning state of the BMH
-  FAILS="$(iterate check_provisioning_status "${MACHINE_NAME}" "${BMH_NAME}" \
-    "${PROVISIONED_STATUS}")"
+  iterate check_provisioning_status "${MACHINE_NAME}" "${BMH_NAME}" \
+    "${PROVISIONED_STATUS}"
+
+  BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
 
   #Check the image
-  FAILS="$(equals "$(echo "${BMH}" | jq -r '.spec.image.url')" \
-    "${IMAGE_NAME}" \
-    "${MACHINE_NAME} Baremetal host correct image")"
+  RESULT_STR="${MACHINE_NAME} Baremetal host correct image"
+  equals "$(echo "${BMH}" | jq -r '.spec.image.url')" \
+    "${IMAGE_NAME}"
 
   # Check the error message and operational status
-  FAILS="$(equals "$(echo "${BMH}" | jq -r '.status.errorMessage')" \
-    "" "${MACHINE_NAME} Baremetal host no error message")"
-  FAILS="$(equals "$(echo "${BMH}" | jq -r '.status.operationalStatus')" \
-    "OK" "${MACHINE_NAME} Baremetal host operational status ok")"
+  RESULT_STR="${MACHINE_NAME} Baremetal host no error message"
+  equals "$(echo "${BMH}" | jq -r '.status.errorMessage')" ""
+  RESULT_STR="${MACHINE_NAME} Baremetal host operational status ok"
+  equals "$(echo "${BMH}" | jq -r '.status.operationalStatus')" "OK"
 
-  echo "${FAILS}"
-  if [[ "${FAILS_CHECK}" != "${FAILS}" ]]; then
-    return 1
-  fi
-  return 0
+  return "$((FAILS-FAILS_CHECK))"
 }
 
 #
@@ -163,25 +147,21 @@ get_vm_ip(){
 # provision the machines
 for name in $MACHINES_LIST; do
   # Create the machines
+  RESULT_STR="${name} machine CR created"
   ./create_machine.sh "${name}" > /dev/null
-  RET_CODE="$?"
-  FAILS="$(process_status "${RET_CODE}" "${name} machine CR created")"
-  [[ "${RET_CODE}" != 0 ]] && SKIP_RETRIES=true
+  process_status "$?" || SKIP_RETRIES=true
 done
 
 # Test provisioning
 for name in $MACHINES_LIST; do
 
   # Verify the machine CR exists
+  RESULT_STR="${name} machine CR exist"
   kubectl get machine -n metal3 -o json "${name}" > /dev/null
-  RET_CODE="$?"
-  FAILS="$(process_status "${RET_CODE}" "${name} machine CR exist")"
-  [[ "${RET_CODE}" != 0 ]] && SKIP_RETRIES=true
+  process_status "$?" || SKIP_RETRIES=true
 
   #Verify that the machine has a bmh associated
-  FAILS="$(iterate check_bmh_association "${name}")"
-  # shellcheck disable=SC2181
-  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+  iterate check_bmh_association "${name}" || SKIP_RETRIES=true
 
   # Get the machine and BMH
   MACHINE="$(kubectl get machine -n metal3 -o json "${name}")"
@@ -190,26 +170,23 @@ for name in $MACHINES_LIST; do
     tr '/' ' ' | awk '{print $2}')"
   BMH="$(kubectl get bmh -n metal3 -o json "${BMH_NAME}")"
   # shellcheck disable=SC2181
-  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+  [[ "$?" == 0 ]] || SKIP_RETRIES=true
 
   # Check the baremetal hosts status fields
-  FAILS="$(check_bmh_status "${name}" "${BMH_NAME}" "$(echo "${MACHINE}" | \
-    jq -r '.spec.providerSpec.value.image.url')" "provisioned")"
+  check_bmh_status "${name}" "${BMH_NAME}" "$(echo "${MACHINE}" | \
+    jq -r '.spec.providerSpec.value.image.url')" "provisioned"
 
   # Get the IP of the BMH
+  RESULT_STR="${name} get baremetal host IP"
   VM_IP="$(get_vm_ip "${BMH_NAME}")"
-  RET_CODE="$?"
-  FAILS="$(process_status "${RET_CODE}" "${name} get baremetal host IP")"
-  [[ "${RET_CODE}" != 0 ]] && SKIP_RETRIES=true
+  process_status "$?" || SKIP_RETRIES=true
 
   # Check ssh connection to BMH
-  FAILS="$(iterate ssh_to_machine "centos" "${VM_IP}" "${name}")"
-  # shellcheck disable=SC2181
-  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+  if iterate ssh_to_machine "centos" "${VM_IP}" "${name}"; then
+    SKIP_RETRIES=true
+  fi
 
-  echo "" >&3
 done
-echo "" >&3
 
 SKIP_RETRIES="${SKIP_RETRIES_USER}"
 
@@ -221,22 +198,20 @@ for name in $MACHINES_LIST; do
     jq -r '.metadata.annotations["metal3.io/BareMetalHost"]' | \
     tr '/' ' ' | awk '{print $2}')"
   # shellcheck disable=SC2181
-  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+  [[ "$?" == 0 ]] || SKIP_RETRIES=true
 
   # Deprovision the machine
+  # shellcheck disable=SC2034
+  RESULT_STR="${name} machine CR deleted"
   kubectl delete machine -n metal3 "${name}" > /dev/null
-  FAILS="$(process_status $? "${name} machine CR deleted")"
+  process_status $?
 
   # Check the status fields of the BMH previously associated
-  FAILS="$(check_bmh_status "${name}" "${BMH_NAME}" "null" "ready")"
-  # shellcheck disable=SC2181
-  [[ "$?" != 0 ]] && SKIP_RETRIES=true
+  if check_bmh_status "${name}" "${BMH_NAME}" "null" "ready"; then
+    SKIP_RETRIES=true
+  fi
 
-  echo "" >&3
 done
-echo "" >&3
 
-
-
-echo -e "\nNumber of failures : $FAILS" >&3
+echo -e "\nNumber of failures : $FAILS"
 exit "${FAILS}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: install_requirements configure_host launch_mgmt_cluster
+all: install_requirements configure_host launch_mgmt_cluster verify
 
 install_requirements:
 	./01_install_requirements.sh

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,8 @@ delete_mgmt_cluster:
 host_cleanup:
 	./host_cleanup.sh
 
+test:
+	./05_test.sh
 
-.PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify
+
+.PHONY: all install_requirements configure_host launch_mgmt_cluster clean delete_mgmt_cluster host_cleanup verify test

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ The `Makefile` runs a series of scripts, described here:
 * `03_launch_mgmt_cluster.sh` - Launch a management cluster using `minikube` and
   run the `baremetal-operator` on that cluster.
 
+* `04_verify.sh` - Runs a set of tests that verify that the deployment completed
+  successfully
+
 To tear down the environment, run `make clean`.
+
+You can also run some tests provisioning and deprovisioning machines by running
+`make test`
 
 ## Note
 If you see this error during the installation:

--- a/config_example.sh
+++ b/config_example.sh
@@ -56,3 +56,21 @@
 # Run a local CAPI operator instead of deploying in Kubernetes
 #
 #export CAPBM_RUN_LOCAL=true
+
+#
+# Do not retry on failure during verifications or tests of the environment
+# This should be true. It could only be set to false for verifications of a
+# dev env deployment that fully completed. Otherwise failures will appear as
+# resources are not ready.
+#
+#export SKIP_RETRIES=false
+
+#
+# Interval between retries after verification or test failure
+#
+#export TEST_TIME_INTERVAL=10
+
+#
+# Number of maximum verification or test retries
+#
+#export TEST_MAX_TIME=120


### PR DESCRIPTION
Avoid failing without retrying to wait for the dev env
to initialize properly. Add verify target in Makefile all
Add a provisioning test script that verifies the provisioning and deprovisioning of the machines