### PR TITLE
Add CAPI v1alpha2 & CAPBPK controllers & CRDs

### DIFF
--- a/03_launch_mgmt_cluster.sh
+++ b/03_launch_mgmt_cluster.sh
@@ -27,10 +27,19 @@ M3PATH="${GOPATH}/src/github.com/metal3-io"
 BMOPATH="${M3PATH}/baremetal-operator"
 CAPBMPATH="${M3PATH}/cluster-api-provider-baremetal"
 
+CAPIPATH="${M3PATH}/cluster-api"
+CABPKPATH="${M3PATH}/cluster-api-bootstrap-provider-kubeadm"
+
 BMOREPO="${BMOREPO:-https://github.com/metal3-io/baremetal-operator.git}"
 BMOBRANCH="${BMOBRANCH:-master}"
 CAPBMREPO="${CAPBMREPO:-https://github.com/metal3-io/cluster-api-provider-baremetal.git}"
 CAPBMBRANCH="${CAPBMBRANCH:-master}"
+
+CAPIREPO="${CAPIREPO:-https://github.com/kubernetes-sigs/cluster-api.git}" 
+CAPIBRANCH="${CAPIBRANCH:-master}"
+CABPKREPO="${CABPKREPO:-https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm.git}" 
+CABPKBRANCH="${CABPKBRANCH:-master}"
+
 FORCE_REPO_UPDATE="${FORCE_REPO_UPDATE:-false}"
 
 BMO_RUN_LOCAL="${BMO_RUN_LOCAL:-false}"
@@ -60,6 +69,31 @@ function clone_repos() {
     fi
     pushd "${CAPBMPATH}"
     git checkout "${CAPBMBRANCH}"
+    git pull -r || true
+    popd
+
+    if [[ -d "${CAPIPATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
+      rm -rf "${CAPIPATH}"
+    fi
+    if [ ! -d "${CAPIPATH}" ] ; then
+        pushd "${M3PATH}"
+        git clone "${CAPIREPO}"
+        popd
+    fi
+    pushd "${CAPIPATH}"
+    git checkout "${CAPIBRANCH}"
+    git pull -r || true
+    popd
+    if [[ -d "${CABPKPATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
+      rm -rf "${CABPKPATH}"
+    fi
+    if [ ! -d "${CABPKPATH}" ] ; then
+        pushd "${M3PATH}"
+        git clone "${CABPKREPO}"
+        popd
+    fi
+    pushd "${CABPKPATH}"
+    git checkout "${CABPKBRANCH}"
     git pull -r || true
     popd
 }
@@ -97,9 +131,9 @@ function apply_bm_hosts() {
 }
 
 #
-# Launch the cluster-api controller manager in the metal3 namespace.
+# Launch the cluster-api controller manager (v1alpha1) in the metal3 namespace.
 #
-function launch_cluster_api() {
+function launch_cluster_api_provider_baremetal() {
     pushd "${CAPBMPATH}"
     if [ "${CAPBM_RUN_LOCAL}" = true ]; then
       touch capbm.out.log
@@ -113,9 +147,36 @@ function launch_cluster_api() {
     popd
 }
 
+#
+# Launch the cluster-api-controller manager (v1alpha2) in the system namespace.
+#
+
+function launch_core_cluster_api() {
+    pushd "${CAPIPATH}"
+      make generate
+      sed -i'' 's/capi-system/metal3/' config/default/kustomization.yaml
+      kustomize build config/default | kubectl apply -f -
+    popd
+}
+
+#
+# Launch the cluster-api-bootstrap-provider-kubeadm-controller manager (v1alpha2) in the metal3 namespace.
+#
+
+function launch_cluster_api_bootstrap_provider_kubeadm() {
+    pushd "${CABPKPATH}"
+      sed -i'' 's/cabpk-system/metal3/' config/default/kustomization.yaml
+      make deploy
+    popd
+}
+
 clone_repos
 sudo su -l -c 'minikube start' "${USER}"
 sudo su -l -c 'minikube ssh sudo ip addr add 172.22.0.2/24 dev eth2' "${USER}"
 launch_baremetal_operator
 apply_bm_hosts
-launch_cluster_api
+launch_cluster_api_provider_baremetal
+if [ "${V1ALPHA2_SWITCH}" == true ]; then
+  launch_core_cluster_api
+  launch_cluster_api_bootstrap_provider_kubeadm
+fi

--- a/config_example.sh
+++ b/config_example.sh
@@ -79,3 +79,7 @@
 # Set the driver. The default value is 'ipmi'
 #
 #export BMC_DRIVER="redfish"
+
+# Install v1alpha2 controllers and CRDs
+#
+#export V1ALPHA2_SWITCH=false

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -66,6 +66,12 @@ export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
 export IRONIC_DATA_DIR="$WORKING_DIR/ironic"
 export IRONIC_IMAGE_DIR="$IRONIC_DATA_DIR/html/images"
 
+# Config for OpenStack CLI
+export OPENSTACK_CONFIG=$HOME/.config/openstack/clouds.yaml
+
+# v1alpha2 var
+export V1ALPHA2_SWITCH=${V1ALPHA2_SWITCH:-"false"}
+
 # Test and verification related variables
 SKIP_RETRIES="${SKIP_RETRIES:-false}"
 TEST_TIME_INTERVAL="${TEST_TIME_INTERVAL:-10}"


### PR DESCRIPTION
Adds CAPI v1alpha2 & CAPBPK controllers & CRDs in dev-env. The ```V1ALPHA2_SWITCH``` flag determines if we want to install the above mentioned entities in dev-env or not. 
