### PR TITLE
Use python3 to build Metal3-dev-env

### DIFF
--- a/ubuntu_install_requirements.sh
+++ b/ubuntu_install_requirements.sh
@@ -20,7 +20,6 @@ sudo apt -y update
 # ansible uses default python2 (python-pip) to run on the local machine
 sudo apt -y install \
   python3-pip \
-  python-pip \
   python-setuptools \
   zlib1g-dev \
   libssl1.0-dev \

--- a/vm-setup/inventory.ini
+++ b/vm-setup/inventory.ini
@@ -1,2 +1,5 @@
 [virthost]
 localhost
+
+[virthost:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/vm-setup/roles/packages_installation/defaults/main.yml
+++ b/vm-setup/roles/packages_installation/defaults/main.yml
@@ -23,9 +23,6 @@ packages:
      - libpolkit-agent-1-0
      - libpolkit-backend-1-0
      - libpolkit-gobject-1-0
-    pip: # ansible uses these packages in python2 to run on the local machine
-     - libvirt-python==5.10.0
-     - lxml
     pip3:
      - virtualbmc
      - python-ironicclient
@@ -34,7 +31,7 @@ packages:
      - netaddr
      - requests
      - setuptools
-     - libvirt-python
+     - libvirt-python==5.10.0
      - python-openstackclient
   centos:
     rhel7:

--- a/vm-setup/roles/packages_installation/tasks/main.yml
+++ b/vm-setup/roles/packages_installation/tasks/main.yml
@@ -5,11 +5,6 @@
         name: "{{ packages.ubuntu.packages}}"
         state: present
       become: true
-    - name: Install packages using pip # ansible uses these packages in python2 to run on the local machine
-      pip:
-        name: "{{ packages.ubuntu.pip }}"
-        state: present
-      become: true
     - name: Install packages using pip3
       pip:
         executable: "pip3"


### PR DESCRIPTION
Use Pyhon3 as default Python interpreter in Ansible playbooks as Python2 EOL has passed.
