### PR TITLE
🌱 Move mboukhalfa to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,6 +12,7 @@ emeritus_approvers:
 - furkatgofurov7
 - hardys
 - maelk
+- mboukhalfa
 
 emeritus_reviewers:
 - jan-est

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
   - elfosardo
   - kashifest
   - lentzi90
-  - mboukhalfa
   - Rozzii
   - smoshiur1237
   - tuminoid


### PR DESCRIPTION
What this PR does / why we need it:
I can't commit to being an approver in this repo, so I am moving myself to emeritus approvers.